### PR TITLE
add missing accounts for place make/take

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -628,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.13.0"
+version = "1.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c041d3eab048880cb0b86b256447da3f18859a163c3b8d8893f4e6368abe6393"
+checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -643,7 +643,7 @@ checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -702,7 +702,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.3",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -845,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1031,7 +1031,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1059,8 +1059,8 @@ dependencies = [
 
 [[package]]
 name = "drift"
-version = "2.61.0"
-source = "git+https://github.com/drift-labs/protocol-v2.git?tag=v2.61.0#45f3fba38b1479f2f96c535fb6f0645837f006d4"
+version = "2.66.0"
+source = "git+https://github.com/drift-labs/protocol-v2.git?tag=v2.66.0#83ce0fb2a11550d6fc52c5029420454a310dee1d"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -1229,7 +1229,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1418,7 +1418,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1525,7 +1525,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.11",
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -1576,9 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379dada1584ad501b383485dd706b8afb7a70fcbc7f4da7d780638a5a6124a60"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -1791,9 +1791,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1832,7 +1832,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.8",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -2020,9 +2020,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
@@ -2251,7 +2251,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.8",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -2335,7 +2335,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2540,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "pyth"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/protocol-v2.git?tag=v2.61.0#45f3fba38b1479f2f96c535fb6f0645837f006d4"
+source = "git+https://github.com/drift-labs/protocol-v2.git?tag=v2.66.0#83ce0fb2a11550d6fc52c5029420454a310dee1d"
 dependencies = [
  "anchor-lang",
  "arrayref",
@@ -2715,9 +2715,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
+checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
 dependencies = [
  "either",
  "rayon-core",
@@ -3087,7 +3087,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4059,9 +4059,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
@@ -4109,9 +4109,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -4145,22 +4145,22 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4255,7 +4255,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4365,7 +4365,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.5",
  "toml_datetime",
  "winnow",
 ]
@@ -4395,7 +4395,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4636,7 +4636,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 2.0.50",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
@@ -4670,7 +4670,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 2.0.50",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4753,7 +4753,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.3",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -4771,7 +4771,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.3",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -4791,17 +4791,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.3",
- "windows_aarch64_msvc 0.52.3",
- "windows_i686_gnu 0.52.3",
- "windows_i686_msvc 0.52.3",
- "windows_x86_64_gnu 0.52.3",
- "windows_x86_64_gnullvm 0.52.3",
- "windows_x86_64_msvc 0.52.3",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -4812,9 +4812,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4824,9 +4824,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4836,9 +4836,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4848,9 +4848,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4860,9 +4860,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4872,9 +4872,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4884,9 +4884,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.3"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
@@ -4970,7 +4970,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 2.0.50",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ test_utils = []
 anchor-lang = "0.27.0"
 bytemuck = "1.13.0"
 base64 = "0.13"
-drift = { git = "https://github.com/drift-labs/protocol-v2.git", tag = "v2.61.0", features = [
+drift = { git = "https://github.com/drift-labs/protocol-v2.git", tag = "v2.66.0", features = [
     "mainnet-beta",
 ] }
 env_logger = "0.10.1"
@@ -31,7 +31,7 @@ tokio-tungstenite = { version = "0.21.0", features = ["native-tls"] }
 regex = "1.10.2"
 
 [dev-dependencies]
-pyth = { git = "https://github.com/drift-labs/protocol-v2.git", tag = "v2.61.0", features = [
+pyth = { git = "https://github.com/drift-labs/protocol-v2.git", tag = "v2.66.0", features = [
     "no-entrypoint",
 ] }
 borsh = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -462,12 +462,11 @@ impl<T: AccountProvider> DriftClient<T> {
         self.backend.get_account(&user_pubkey).await
     }
 
-    /// Get your user stats account
+    /// Get user stats account of current wallet
     ///
-    /// Returns the deserialize account data (`UserStats`)
-    pub async fn get_user_stats(&self, authority: &Pubkey) -> SdkResult<UserStats> {
-        let user_stats_pubkey = Wallet::derive_stats_account(authority, &constants::PROGRAM_ID);
-        self.backend.get_account(&user_stats_pubkey).await
+    /// Returns the deserialized account data (`UserStats`)
+    pub async fn get_user_stats(&self) -> SdkResult<UserStats> {
+        self.backend.get_account(&self.wallet.stats).await
     }
 
     /// Get the latest recent_block_hash
@@ -1179,7 +1178,7 @@ impl<'a> TransactionBuilder<'a> {
                 state: *state_account(),
                 authority: self.authority,
                 user: self.sub_account,
-                user_stats: Wallet::derive_stats_account(&self.sub_account, &constants::PROGRAM_ID),
+                user_stats: Wallet::derive_stats_account(&self.authority, &constants::PROGRAM_ID),
                 taker: *taker,
                 taker_stats: Wallet::derive_stats_account(taker, &constants::PROGRAM_ID),
             },
@@ -1335,7 +1334,7 @@ impl<'a> TransactionBuilder<'a> {
 ///
 /// `markets_readable` IDs of markets to include as readable
 ///
-/// `markets_writable` ` IDs of markets to include as writable (takes priority over readable)
+/// `markets_writable` IDs of markets to include as writable (takes priority over readable)
 ///
 /// # Panics
 ///  if the user has positions in an unknown market (i.e unsupported by the SDK)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1256,7 +1256,7 @@ impl<'a> TransactionBuilder<'a> {
                 state: *state_account(),
                 authority: self.authority,
                 user: self.sub_account,
-                user_stats: Wallet::derive_stats_account(&self.sub_account, &constants::PROGRAM_ID),
+                user_stats: Wallet::derive_stats_account(&self.authority, &constants::PROGRAM_ID),
             },
             user_accounts.as_slice(),
             &[],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1228,8 +1228,11 @@ impl<'a> TransactionBuilder<'a> {
     /// Add a place and take instruction
     ///
     /// `order` the order to place
+    ///
     /// `maker_info` pubkey of the maker/counterparty to take against and account data
+    ///
     /// `referrer` pubkey of the maker's referrer account, if any
+    ///
     /// `fulfilment_type` type of fill for spot orders, ignored for perp orders
     pub fn place_and_take(
         mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1157,17 +1157,23 @@ impl<'a> TransactionBuilder<'a> {
     /// Add a place and make instruction
     ///
     /// `order` the order to place
-    /// `taker` taker account address
+    /// `taker_info` taker account address and data
     /// `taker_order_id` the id of the taker's order to match with
+    /// `referrer` pukey of the taker's referrer account, if any
     /// `fulfilment_type` type of fill for spot orders, ignored for perp orders
     pub fn place_and_make(
         mut self,
         order: OrderParams,
-        taker: &Pubkey,
+        taker_info: &(Pubkey, User),
         taker_order_id: u32,
+        referrer: Option<Pubkey>,
         fulfillment_type: Option<SpotFulfillmentType>,
     ) -> Self {
-        let accounts = build_accounts(
+        let (taker, taker_account) = taker_info;
+        let is_perp = order.market_type == MarketType::Perp;
+        let perp_writable = [MarketId::perp(order.market_index)];
+        let spot_writable = [MarketId::spot(order.market_index), MarketId::QUOTE_SPOT];
+        let mut accounts = build_accounts(
             self.program_data,
             drift::accounts::PlaceAndMake {
                 state: *state_account(),
@@ -1177,10 +1183,22 @@ impl<'a> TransactionBuilder<'a> {
                 taker: *taker,
                 taker_stats: Wallet::derive_stats_account(taker, &constants::PROGRAM_ID),
             },
-            &[self.account_data.as_ref()],
+            &[self.account_data.as_ref(), &taker_account],
             &[],
-            &[],
+            if is_perp {
+                &perp_writable
+            } else {
+                &spot_writable
+            },
         );
+
+        if let Some(referrer) = referrer {
+            accounts.push(AccountMeta::new(
+                Wallet::derive_stats_account(&referrer, &constants::PROGRAM_ID),
+                false,
+            ));
+            accounts.push(AccountMeta::new(referrer, false));
+        }
 
         let ix = if order.market_type == MarketType::Perp {
             Instruction {
@@ -1210,13 +1228,26 @@ impl<'a> TransactionBuilder<'a> {
     /// Add a place and take instruction
     ///
     /// `order` the order to place
+    /// `maker_info` pubkey of the maker/counterparty to take against and account data
+    /// `referrer` pubkey of the maker's referrer account, if any
     /// `fulfilment_type` type of fill for spot orders, ignored for perp orders
     pub fn place_and_take(
         mut self,
         order: OrderParams,
+        maker_info: Option<(Pubkey, User)>,
+        referrer: Option<Pubkey>,
         fulfillment_type: Option<SpotFulfillmentType>,
     ) -> Self {
-        let accounts = build_accounts(
+        let mut user_accounts = vec![self.account_data.as_ref()];
+        if let Some((ref _maker_pubkey, ref maker)) = maker_info {
+            user_accounts.push(maker);
+        }
+
+        let is_perp = order.market_type == MarketType::Perp;
+        let perp_writable = [MarketId::perp(order.market_index)];
+        let spot_writable = [MarketId::spot(order.market_index), MarketId::QUOTE_SPOT];
+
+        let mut accounts = build_accounts(
             self.program_data,
             drift::accounts::PlaceAndTake {
                 state: *state_account(),
@@ -1224,12 +1255,25 @@ impl<'a> TransactionBuilder<'a> {
                 user: self.sub_account,
                 user_stats: Wallet::derive_stats_account(&self.sub_account, &constants::PROGRAM_ID),
             },
-            &[self.account_data.as_ref()],
+            user_accounts.as_slice(),
             &[],
-            &[],
+            if is_perp {
+                &perp_writable
+            } else {
+                &spot_writable
+            },
         );
 
-        let ix = if order.market_type == MarketType::Perp {
+        if referrer.is_some_and(|r| !maker_info.is_some_and(|(m, _)| m == r)) {
+            let referrer = referrer.unwrap();
+            accounts.push(AccountMeta::new(
+                Wallet::derive_stats_account(&referrer, &constants::PROGRAM_ID),
+                false,
+            ));
+            accounts.push(AccountMeta::new(referrer, false));
+        }
+
+        let ix = if is_perp {
             Instruction {
                 program_id: constants::PROGRAM_ID,
                 accounts,

--- a/src/liquidation.rs
+++ b/src/liquidation.rs
@@ -292,8 +292,8 @@ pub fn calculate_liquidation_price_inner(
 
     let margin_calculation = calculate_margin_requirement_and_total_collateral_and_liability_info(
         user,
-        &perp_market_map,
-        &spot_market_map,
+        perp_market_map,
+        spot_market_map,
         oracle_map,
         MarginContext::standard(MarginRequirementType::Maintenance),
     )

--- a/src/liquidation.rs
+++ b/src/liquidation.rs
@@ -505,38 +505,24 @@ mod tests {
         }
     }
 
+    #[ignore]
     #[tokio::test]
     async fn calculate_liq_price() {
         let wallet = Wallet::read_only(
-            // DxoRJ4f5XRMvXU9SGuM4ZziBFUxbhB3ubur5sVZEvue2
-            Pubkey::from_str("BTEa9vssaG61XAhzPTtNtvVFpB1EARNwaTffTqA43YzT").unwrap(),
+            Pubkey::from_str("DxoRJ4f5XRMvXU9SGuM4ZziBFUxbhB3ubur5sVZEvue2").unwrap(),
         );
         let client = DriftClient::new(
-            crate::Context::MainNet,
-            RpcAccountProvider::new(
-                "https://mainnet.helius-rpc.com/?api-key=53ee88d4-b06c-428c-b3d8-9023261653af",
-            ),
-            // crate::Context::DevNet,
-            // RpcAccountProvider::new("https://api.devnet.solana.com"),
+            crate::Context::DevNet,
+            RpcAccountProvider::new("https://api.devnet.solana.com"),
             wallet.clone(),
         )
         .await
         .unwrap();
         let user = client
-            .get_user_account(&wallet.sub_account(2))
-            .await
-            .unwrap();
-
-        dbg!(
-            calculate_liquidation_price_and_unrealized_pnl(&client, &user, 24)
-                .await
-                .unwrap()
-        );
-
-        let user = client
             .get_user_account(&wallet.sub_account(0))
             .await
             .unwrap();
+
         dbg!(
             calculate_liquidation_price_and_unrealized_pnl(&client, &user, 24)
                 .await

--- a/src/types.rs
+++ b/src/types.rs
@@ -97,6 +97,7 @@ pub struct NewOrder {
     ioc: bool,
     amount: u64,
     price: u64,
+    user_order_id: u8,
 }
 
 impl NewOrder {
@@ -149,6 +150,11 @@ impl NewOrder {
         self.post_only = value;
         self
     }
+    /// Set user order id
+    pub fn user_order_id(mut self, user_order_id: u8) -> Self {
+        self.user_order_id = user_order_id;
+        self
+    }
     /// Call to complete building the Order
     pub fn build(self) -> OrderParams {
         OrderParams {
@@ -161,6 +167,7 @@ impl NewOrder {
             direction: self.direction,
             immediate_or_cancel: self.ioc,
             post_only: self.post_only,
+            user_order_id: self.user_order_id,
             ..Default::default()
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,6 @@
 use drift::math::constants::{BASE_PRECISION_I64, LAMPORTS_PER_SOL_I64, PRICE_PRECISION_U64};
 use drift_sdk::{
-    types::{ClientOpts, Context, MarketId, NewOrder},
+    types::{Context, MarketId, NewOrder},
     DriftClient, RpcAccountProvider, Wallet,
 };
 use solana_sdk::signature::Keypair;
@@ -13,11 +13,10 @@ fn test_keypair() -> Keypair {
 
 #[tokio::test]
 async fn get_oracle_prices() {
-    let client = DriftClient::new_with_opts(
+    let client = DriftClient::new(
         Context::DevNet,
         RpcAccountProvider::new("https://api.devnet.solana.com"),
         Keypair::new().into(),
-        ClientOpts::default(),
     )
     .await
     .expect("connects");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -85,7 +85,6 @@ async fn place_and_take() {
     let order = NewOrder::limit(sol_perp)
         .amount(1 * BASE_PRECISION_I64)
         .price(40 * PRICE_PRECISION_U64)
-        .post_only(drift_sdk::types::PostOnlyParam::MustPostOnly)
         .build();
     let tx = client
         .init_tx(&wallet.default_sub_account(), false)


### PR DESCRIPTION
## Fixes:
- missing accounts for place_and_make/take
- liquidation price matches UI (handle LP shares and open orders)
- unrealized PnL matches UI (don't include settled pnl)

## Changes
- bumped drift-program to v2.66.0
- tidied this function to use the wallet
```
 pub async fn get_user_stats(&self) -> SdkResult<UserStats> {
        self.backend.get_account(&self.wallet.stats).await
    }
```

integration tests busted on devnet