### PR TITLE
Remove async

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,21 +605,21 @@ impl<T: AccountProvider> DriftClient<T> {
     ///     .build();
     /// ```
     /// Returns a `TransactionBuilder` for composing the tx
-    pub fn init_tx(
-        &self,
-        account: &Pubkey,
-        delegated: bool,
-    ) -> SdkResult<TransactionBuilder> {
-        let account_data = self
-            .get_user(self.active_sub_account_id)
-            .expect("user")
-            .get_user_account();
-        Ok(TransactionBuilder::new(
-            self.program_data(),
-            *account,
-            Cow::Owned(account_data),
-            delegated,
-        ))
+    pub fn init_tx(&self, account: &Pubkey, delegated: bool) -> SdkResult<TransactionBuilder> {
+        let user = self.get_user(self.active_sub_account_id);
+
+        match user {
+            Some(user) => {
+                let account_data = user.get_user_account();
+                Ok(TransactionBuilder::new(
+                    self.program_data(),
+                    *account,
+                    Cow::Owned(account_data),
+                    delegated,
+                ))
+            }
+            None => Err(SdkError::Generic("user".to_string())),
+        }
     }
 
     pub async fn get_recent_priority_fees(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -605,7 +605,7 @@ impl<T: AccountProvider> DriftClient<T> {
     ///     .build();
     /// ```
     /// Returns a `TransactionBuilder` for composing the tx
-    pub async fn init_tx(
+    pub fn init_tx(
         &self,
         account: &Pubkey,
         delegated: bool,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -60,7 +60,6 @@ async fn place_and_cancel_orders() {
 
     let tx = client
         .init_tx(&wallet.default_sub_account(), false)
-        .await
         .unwrap()
         .cancel_all_orders()
         .place_orders(vec![
@@ -104,7 +103,6 @@ async fn place_and_take() {
         .build();
     let tx = client
         .init_tx(&wallet.default_sub_account(), false)
-        .await
         .unwrap()
         .place_and_take(order, None, None, None)
         .build();


### PR DESCRIPTION
### Motivation
- There is not method that should await inside `init_tx`. So I think we can remove `async` keyword of `init_tx` function.

#### Solution
- Remove `async` keyword from `init_tx` function.