### PR TITLE
async calculations

### DIFF
--- a/crates/src/drift_idl.rs
+++ b/crates/src/drift_idl.rs
@@ -2,7 +2,6 @@
 #![doc = r""]
 #![doc = r" Auto-generated IDL types, manual edits do not persist (see `crates/drift-idl-gen`)"]
 #![doc = r""]
-use self::traits::ToAccountMetas;
 use anchor_lang::{
     prelude::{
         account,
@@ -12,6 +11,8 @@ use anchor_lang::{
     Discriminator,
 };
 use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey};
+
+use self::traits::ToAccountMetas;
 pub mod traits {
     use solana_sdk::instruction::AccountMeta;
     #[doc = r" This is distinct from the anchor version of the trait"]
@@ -1801,8 +1802,9 @@ pub mod instructions {
     impl anchor_lang::InstructionData for InitializePythPullOracle {}
 }
 pub mod types {
-    use super::*;
     use std::ops::Mul;
+
+    use super::*;
     #[doc = r" backwards compatible u128 deserializing data from rust <=1.76.0 when u/i128 was 8-byte aligned"]
     #[doc = r" https://solana.stackexchange.com/questions/7720/using-u128-without-sacrificing-alignment-8"]
     #[derive(

--- a/crates/src/lib.rs
+++ b/crates/src/lib.rs
@@ -401,7 +401,7 @@ impl DriftClient {
         {
             Ok(market.data)
         } else {
-            Err(SdkError::NoData)
+            Err(SdkError::NoMarketData(MarketId::spot(market_index)))
         }
     }
 
@@ -415,7 +415,7 @@ impl DriftClient {
         {
             Ok(market.data)
         } else {
-            Err(SdkError::NoData)
+            Err(SdkError::NoMarketData(MarketId::perp(market_index)))
         }
     }
 
@@ -744,7 +744,7 @@ impl DriftClientBackend {
     fn try_get_account<T: AccountDeserialize>(&self, account: &Pubkey) -> SdkResult<T> {
         self.account_map
             .account_data(account)
-            .ok_or(SdkError::NoData)
+            .ok_or_else(|| SdkError::NoAccountData(account.clone()))
     }
 
     /// Returns latest blockhash

--- a/crates/src/lib.rs
+++ b/crates/src/lib.rs
@@ -367,7 +367,7 @@ impl DriftClient {
         {
             Some(market) => Ok(market.data),
             None => {
-                debug!(target: "rpc", "fetch spot market: {market_index}");
+                debug!(target: "rpc", "fetch market: spot/{market_index}");
                 let market = derive_spot_market_account(market_index);
                 self.backend.get_account(&market).await
             }
@@ -384,7 +384,7 @@ impl DriftClient {
         {
             Some(market) => Ok(market.data),
             None => {
-                debug!(target: "rpc", "fetch perp market: {market_index}");
+                debug!(target: "rpc", "fetch market: perp/{market_index}");
                 let market = derive_perp_market_account(market_index);
                 self.backend.get_account(&market).await
             }

--- a/crates/src/math/account_map_builder.rs
+++ b/crates/src/math/account_map_builder.rs
@@ -82,7 +82,95 @@ impl AccountsListBuilder {
         for (oracle_key, market) in oracle_markets.iter() {
             let oracle = client
                 .try_get_oracle_price_data_and_slot(*market)
-                .ok_or(SdkError::NoData)?;
+                .ok_or(SdkError::NoMarketData(*market))?;
+
+            latest_oracle_slot = oracle.slot.max(oracle.slot);
+            let oracle_owner = oracle_source_to_owner(client.context, oracle.source);
+            self.oracle_accounts.push(
+                (
+                    *oracle_key,
+                    Account {
+                        data: oracle.raw,
+                        owner: oracle_owner,
+                        ..Default::default()
+                    },
+                )
+                    .into(),
+            );
+        }
+
+        Ok(AccountsList {
+            perp_markets: self.perp_accounts.as_mut_slice(),
+            spot_markets: self.spot_accounts.as_mut_slice(),
+            oracles: self.oracle_accounts.as_mut_slice(),
+            oracle_guard_rails: Some(drift_state_account.oracle_guard_rails),
+            latest_slot: latest_oracle_slot,
+        })
+    }
+
+    /// Constructs an account map from `user` positions
+    ///
+    /// It relies on the `client` being subscribed to all the necessary markets and oracles
+    pub async fn build(&mut self, client: &DriftClient, user: &User) -> SdkResult<AccountsList> {
+        let mut oracle_markets =
+            HashMap::<Pubkey, MarketId>::with_capacity_and_hasher(16, Default::default());
+        let mut spot_markets = Vec::<SpotMarket>::with_capacity(user.spot_positions.len());
+        let mut perp_markets = Vec::<PerpMarket>::with_capacity(user.perp_positions.len());
+        let drift_state_account = client.try_get_account::<State>(state_account())?;
+
+        for p in user.spot_positions.iter().filter(|p| !p.is_available()) {
+            let market = client.get_spot_market_account(p.market_index).await?;
+            oracle_markets.insert(market.oracle, MarketId::spot(market.market_index));
+            spot_markets.push(market);
+        }
+
+        let quote_market = client
+            .get_spot_market_account(MarketId::QUOTE_SPOT.index())
+            .await?;
+        if oracle_markets
+            .insert(quote_market.oracle, MarketId::QUOTE_SPOT)
+            .is_none()
+        {
+            spot_markets.push(quote_market);
+        }
+
+        for p in user.perp_positions.iter().filter(|p| !p.is_available()) {
+            let market = client.get_perp_market_account(p.market_index).await?;
+            oracle_markets.insert(market.amm.oracle, MarketId::perp(market.market_index));
+            perp_markets.push(market);
+        }
+
+        for market in spot_markets.iter() {
+            self.spot_accounts.push(
+                (
+                    market.pubkey,
+                    Account {
+                        data: zero_account_to_bytes(*market),
+                        owner: constants::PROGRAM_ID,
+                        ..Default::default()
+                    },
+                )
+                    .into(),
+            );
+        }
+
+        for market in perp_markets.iter() {
+            self.perp_accounts.push(
+                (
+                    market.pubkey,
+                    Account {
+                        data: zero_account_to_bytes(*market),
+                        owner: constants::PROGRAM_ID,
+                        ..Default::default()
+                    },
+                )
+                    .into(),
+            );
+        }
+
+        let mut latest_oracle_slot = 0;
+        for (oracle_key, market) in oracle_markets.iter() {
+            let oracle = client.get_oracle_price_data_and_slot(*market).await?;
 
             latest_oracle_slot = oracle.slot.max(oracle.slot);
             let oracle_owner = oracle_source_to_owner(client.context, oracle.source);

--- a/crates/src/math/account_map_builder.rs
+++ b/crates/src/math/account_map_builder.rs
@@ -110,7 +110,8 @@ impl AccountsListBuilder {
 
     /// Constructs an account map from `user` positions
     ///
-    /// It relies on the `client` being subscribed to all the necessary markets and oracles
+    /// like `try_build` but will fall back to network queries to fetch market/oracle accounts as required
+    /// if the client is already subscribed to necessary market/oracles then no network requests are made.
     pub async fn build(&mut self, client: &DriftClient, user: &User) -> SdkResult<AccountsList> {
         let mut oracle_markets =
             HashMap::<Pubkey, MarketId>::with_capacity_and_hasher(16, Default::default());

--- a/crates/src/math/liquidation.rs
+++ b/crates/src/math/liquidation.rs
@@ -22,13 +22,16 @@ use crate::{
     DriftClient, MarketId, SdkError, SdkResult, SpotPosition,
 };
 
-/// Info on a positions liquidation price and unrealized PnL
+/// Info on a position's liquidation price and unrealized PnL
 #[derive(Debug)]
 pub struct LiquidationAndPnlInfo {
     // PRICE_PRECISION
     pub liquidation_price: i64,
     // PRICE_PRECISION
     pub unrealized_pnl: i128,
+    // The oracle price used in calculations
+    // BASE_PRECISION
+    pub oracle_price: i64,
 }
 
 /// Calculate the liquidation price and unrealized PnL of a user's perp position (given by `market_index`)
@@ -79,6 +82,7 @@ pub async fn calculate_liquidation_price_and_unrealized_pnl(
             oracle_price,
             &mut accounts_list,
         )?,
+        oracle_price,
     })
 }
 

--- a/crates/src/types.rs
+++ b/crates/src/types.rs
@@ -313,7 +313,7 @@ pub enum SdkError {
     MaxReconnectionAttemptsReached,
     #[error("jit taker order not found")]
     JitOrderNotFound,
-    #[error("market/oracle data unavailable. subscribe market: {0:?}")]
+    #[error("market data unavailable. subscribe market: {0:?}")]
     NoMarketData(MarketId),
     #[error("account data unavailable. subscribe account: {0:?}")]
     NoAccountData(Pubkey),

--- a/crates/src/types.rs
+++ b/crates/src/types.rs
@@ -313,8 +313,10 @@ pub enum SdkError {
     MaxReconnectionAttemptsReached,
     #[error("jit taker order not found")]
     JitOrderNotFound,
-    #[error("no data. client may be unsubscribed")]
-    NoData,
+    #[error("market/oracle data unavailable. subscribe market: {0:?}")]
+    NoMarketData(MarketId),
+    #[error("account data unavailable. subscribe account: {0:?}")]
+    NoAccountData(Pubkey),
     #[error("component is already subscribed")]
     AlreadySubscribed,
     #[error("invalid URL")]


### PR DESCRIPTION
if client is subscribed calculation will use latest market/oracle values from cache otherwise will fall back to network queries.
adds negligible overhead for subscribed clients, makes it just work when a market/oracle is not subscribed

improved errors when data is unsubscribed, `RUST_LOG=rpc=debug` will output when network queries are being made so users can easily see which subscriptions are required