### PR TITLE
Fix/subscriber reconnects

### DIFF
--- a/crates/src/drift_idl.rs
+++ b/crates/src/drift_idl.rs
@@ -176,7 +176,7 @@ pub mod instructions {
     }
     #[automatically_derived]
     impl anchor_lang::Discriminator for TransferPerpPosition {
-        const DISCRIMINATOR: [u8; 8] = [23, 172, 188, 168, 134, 210, 3, 108];
+        const DISCRIMINATOR: &[u8] = &[23, 172, 188, 168, 134, 210, 3, 108];
     }
     #[automatically_derived]
     impl anchor_lang::InstructionData for TransferPerpPosition {}
@@ -6384,7 +6384,7 @@ pub mod accounts {
     }
     #[automatically_derived]
     impl anchor_lang::Discriminator for TransferPerpPosition {
-        const DISCRIMINATOR: [u8; 8] = [73, 4, 221, 41, 202, 239, 84, 16];
+        const DISCRIMINATOR: &[u8] = &[73, 4, 221, 41, 202, 239, 84, 16];
     }
     #[automatically_derived]
     unsafe impl anchor_lang::__private::bytemuck::Pod for TransferPerpPosition {}
@@ -6429,7 +6429,7 @@ pub mod accounts {
     #[automatically_derived]
     impl anchor_lang::AccountSerialize for TransferPerpPosition {
         fn try_serialize<W: std::io::Write>(&self, writer: &mut W) -> anchor_lang::Result<()> {
-            if writer.write_all(&Self::DISCRIMINATOR).is_err() {
+            if writer.write_all(Self::DISCRIMINATOR).is_err() {
                 return Err(anchor_lang::error::ErrorCode::AccountDidNotSerialize.into());
             }
             if AnchorSerialize::serialize(self, writer).is_err() {

--- a/crates/src/lib.rs
+++ b/crates/src/lib.rs
@@ -703,8 +703,14 @@ impl DriftClientBackend {
             all_oracles.as_slice(),
             rpc_client.commitment(),
         );
-        let account_map = AccountMap::new(Arc::clone(&pubsub_client), rpc_client.commitment());
-        account_map.subscribe_account(state_account()).await?;
+        let account_map = AccountMap::new(
+            Arc::clone(&pubsub_client),
+            Arc::clone(&rpc_client),
+            rpc_client.commitment(),
+        );
+        account_map
+            .subscribe_account_polled(state_account(), None)
+            .await?;
 
         Ok(Self {
             rpc_client: Arc::clone(&rpc_client),
@@ -1863,7 +1869,11 @@ mod tests {
                 Duration::from_secs(2),
                 Arc::clone(&rpc_client),
             ),
-            account_map: AccountMap::new(Arc::clone(&pubsub_client), CommitmentConfig::processed()),
+            account_map: AccountMap::new(
+                Arc::clone(&pubsub_client),
+                Arc::clone(&rpc_client),
+                CommitmentConfig::processed(),
+            ),
         };
 
         DriftClient {

--- a/crates/src/slot_subscriber.rs
+++ b/crates/src/slot_subscriber.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::{atomic::AtomicU64, Arc, Mutex},
-    time::Duration,
-};
+use std::sync::{atomic::AtomicU64, Arc, Mutex};
 
 use drift_pubsub_client::PubsubClient;
 use futures_util::StreamExt;
@@ -102,7 +99,7 @@ impl SlotSubscriber {
                 let (mut slot_updates, unsubscriber) = match pubsub.slot_subscribe().await {
                     Ok(s) => s,
                     Err(err) => {
-                        warn!(target: LOG_TARGET, "subscribe failed: {err:?}");
+                        error!(target: LOG_TARGET, "slot subscribe failed: {err:?}");
                         continue;
                     }
                 };

--- a/crates/src/wallet.rs
+++ b/crates/src/wallet.rs
@@ -1,0 +1,165 @@
+use std::sync::Arc;
+
+use solana_sdk::{
+    hash::Hash,
+    message::VersionedMessage,
+    pubkey::Pubkey,
+    signature::{keypair_from_seed, Keypair, Signature},
+    signer::Signer,
+    transaction::VersionedTransaction,
+};
+
+use crate::{
+    constants::{self},
+    types::{SdkError, SdkResult},
+    utils,
+};
+
+/// Drift wallet
+#[derive(Clone, Debug)]
+pub struct Wallet {
+    /// The signing keypair, it could be authority or delegate
+    signer: Arc<Keypair>,
+    /// The drift 'authority' account
+    /// user (sub)accounts are derived from this
+    authority: Pubkey,
+    /// The drift 'stats' account
+    stats: Pubkey,
+}
+
+impl Wallet {
+    /// Returns true if the wallet is configured for delegated signing
+    pub fn is_delegated(&self) -> bool {
+        self.authority != self.signer.pubkey() && self.signer.pubkey().is_on_curve()
+    }
+    /// Init wallet from a string that could be either a file path or the encoded key, uses default sub-account
+    pub fn try_from_str(path_or_key: &str) -> SdkResult<Self> {
+        let authority = utils::load_keypair_multi_format(path_or_key)?;
+        Ok(Self::new(authority))
+    }
+    /// Construct a read-only wallet
+    pub fn read_only(authority: Pubkey) -> Self {
+        Self {
+            signer: Arc::new(Keypair::new()),
+            authority,
+            stats: Wallet::derive_stats_account(&authority),
+        }
+    }
+    /// Init wallet from base58 encoded seed, uses default sub-account
+    ///
+    /// # panics
+    /// if the key is invalid
+    pub fn from_seed_bs58(seed: &str) -> Self {
+        let authority = Keypair::from_base58_string(seed);
+        Self::new(authority)
+    }
+    /// Init wallet from seed bytes, uses default sub-account
+    pub fn from_seed(seed: &[u8]) -> SdkResult<Self> {
+        let authority = keypair_from_seed(seed).map_err(|_| SdkError::InvalidSeed)?;
+        Ok(Self::new(authority))
+    }
+    /// Init wallet with keypair
+    ///
+    /// * `authority` - keypair for tx signing
+    pub fn new(authority: Keypair) -> Self {
+        Self {
+            stats: Wallet::derive_stats_account(&authority.pubkey()),
+            authority: authority.pubkey(),
+            signer: Arc::new(authority),
+        }
+    }
+    /// Convert the wallet into a delegated one by providing the `authority` public key
+    pub fn to_delegated(&mut self, authority: Pubkey) {
+        self.stats = Wallet::derive_stats_account(&authority);
+        self.authority = authority;
+    }
+    /// Calculate the address of a drift user account/sub-account
+    pub fn derive_user_account(authority: &Pubkey, sub_account_id: u16) -> Pubkey {
+        let (account_drift_pda, _seed) = Pubkey::find_program_address(
+            &[
+                &b"user"[..],
+                authority.as_ref(),
+                &sub_account_id.to_le_bytes(),
+            ],
+            &constants::PROGRAM_ID,
+        );
+        account_drift_pda
+    }
+
+    /// Calculate the address of a drift stats account
+    pub fn derive_stats_account(account: &Pubkey) -> Pubkey {
+        let (account_drift_pda, _seed) = Pubkey::find_program_address(
+            &[&b"user_stats"[..], account.as_ref()],
+            &constants::PROGRAM_ID,
+        );
+        account_drift_pda
+    }
+
+    /// Calculate the address of `authority`s swift (taker) order account
+    pub fn derive_swift_order_account(authority: &Pubkey) -> Pubkey {
+        let (account_drift_pda, _seed) = Pubkey::find_program_address(
+            &[&b"SIGNED_MSG"[..], authority.as_ref()],
+            &constants::PROGRAM_ID,
+        );
+        account_drift_pda
+    }
+
+    /// Signs the given tx `message` returning the tx on success
+    pub fn sign_tx(
+        &self,
+        mut message: VersionedMessage,
+        recent_block_hash: Hash,
+    ) -> SdkResult<VersionedTransaction> {
+        message.set_recent_blockhash(recent_block_hash);
+        let signer: &dyn Signer = self.signer.as_ref();
+        VersionedTransaction::try_new(message, &[signer]).map_err(Into::into)
+    }
+
+    /// Sign message with the wallet's signer
+    pub fn sign_message(&self, message: &[u8]) -> SdkResult<Signature> {
+        let signer: &dyn Signer = self.signer.as_ref();
+        Ok(signer.sign_message(message))
+    }
+    /// Return the wallet authority address
+    pub fn authority(&self) -> &Pubkey {
+        &self.authority
+    }
+    /// Return the wallet signing address
+    pub fn signer(&self) -> Pubkey {
+        self.signer.pubkey()
+    }
+    /// Return the drift user stats address
+    pub fn stats(&self) -> &Pubkey {
+        &self.stats
+    }
+    /// Return the address of the default sub-account (0)
+    pub fn default_sub_account(&self) -> Pubkey {
+        self.sub_account(0)
+    }
+    /// Calculate the drift user address given a `sub_account_id`
+    pub fn sub_account(&self, sub_account_id: u16) -> Pubkey {
+        Self::derive_user_account(self.authority(), sub_account_id)
+    }
+}
+
+impl From<Keypair> for Wallet {
+    fn from(value: Keypair) -> Self {
+        Self::new(value)
+    }
+}
+
+#[cfg(tests)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wallet_read_only() {
+        let keypair = Keypair::new();
+        let ro = Wallet::read_only(keypair.pubkey());
+
+        let rw = Wallet::new(keypair);
+        assert_eq!(rw.authority, ro.authority);
+        assert_eq!(rw.stats, ro.stats);
+        assert_eq!(rw.default_sub_account(), ro.default_sub_account());
+    }
+}

--- a/crates/src/wallet.rs
+++ b/crates/src/wallet.rs
@@ -148,7 +148,7 @@ impl From<Keypair> for Wallet {
     }
 }
 
-#[cfg(tests)]
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/crates/src/websocket_program_account_subscriber.rs
+++ b/crates/src/websocket_program_account_subscriber.rs
@@ -73,40 +73,45 @@ impl WebsocketProgramAccountSubscriber {
 
         tokio::spawn(async move {
             let mut latest_slot = 0;
-            let pubsub = PubsubClient::new(&url).await.expect("connects");
-            let (mut accounts, unsub) = pubsub
-                .program_subscribe(&constants::PROGRAM_ID, Some(config.clone()))
-                .await
-                .expect("subscribes");
-
             loop {
-                tokio::select! {
-                    biased;
-                    message = accounts.next() => {
-                        match message {
-                            Some(message) => {
-                                let slot = message.context.slot;
-                                if slot >= latest_slot {
-                                    latest_slot = slot;
-                                    let pubkey = message.value.pubkey;
-                                    let data = &message.value.account.data.decode().expect("account has data");
-                                    let data = T::deserialize(&mut &data[8..]).expect("deserializes T");
-                                    on_update(&ProgramAccountUpdate::new(pubkey, DataAndSlot::<T> { slot, data }, Instant::now()));
+                let pubsub = PubsubClient::new(&url).await.expect("connects");
+                let (mut accounts, unsub) = pubsub
+                    .program_subscribe(&constants::PROGRAM_ID, Some(config.clone()))
+                    .await
+                    .expect("subscribes");
+
+                let res = loop {
+                    tokio::select! {
+                        biased;
+                        message = accounts.next() => {
+                            match message {
+                                Some(message) => {
+                                    let slot = message.context.slot;
+                                    if slot >= latest_slot {
+                                        latest_slot = slot;
+                                        let pubkey = message.value.pubkey;
+                                        let data = &message.value.account.data.decode().expect("account has data");
+                                        let data = T::deserialize(&mut &data[8..]).expect("deserializes T");
+                                        on_update(&ProgramAccountUpdate::new(pubkey, DataAndSlot::<T> { slot, data }, Instant::now()));
+                                    }
+                                },
+                                None => {
+                                    log::error!("{subscription_name}: Ws GPA stream ended unexpectedly");
+                                    break Err(());
                                 }
-                            },
-                            None => {
-                                log::error!("{subscription_name}: Ws GPA stream ended unexpectedly");
-                                std::process::exit(1); // tokio won't propogate a panic
                             }
                         }
+                        _ = &mut unsub_rx => {
+                            warn!("unsubscribing: {subscription_name}");
+                            unsub().await;
+                            break Ok(());
+                        }
                     }
-                    _ = &mut unsub_rx => {
-                        warn!("unsubscribing: {subscription_name}");
-                        break;
-                    }
+                };
+                if res.is_ok() {
+                    break;
                 }
             }
-            unsub().await;
         });
 
         unsub_tx


### PR DESCRIPTION
changes:
- before: subscriber classes abort the process if the underlying network connections fail, now: continually attempt to reconnect  and log failures
- move wallet to its own module (prep work for later)
- state account subscribes via polling

adds:
- AccountMap supports polling or ws backed connections