### PR TITLE
fix: liquidationPrice calc for mixed perp/spot oracle precision

### DIFF
--- a/crates/src/math/mod.rs
+++ b/crates/src/math/mod.rs
@@ -1,6 +1,9 @@
-use crate::drift_idl::{
-    errors::ErrorCode,
-    types::{MarginCalculationMode, MarginRequirementType, MarketIdentifier},
+use crate::{
+    drift_idl::{
+        errors::ErrorCode,
+        types::{MarginCalculationMode, MarginRequirementType, MarketIdentifier},
+    },
+    types::OracleSource,
 };
 
 pub mod account_list_builder;
@@ -110,5 +113,22 @@ impl MarginContext {
             }
         }
         Ok(self)
+    }
+}
+
+/// Returns (numerator, denominator) pair to normalize prices from 2 different oracle source
+fn get_oracle_normalization_factor(a: OracleSource, b: OracleSource) -> (u64, u64) {
+    match (a, b) {
+        // 1M scaling relationships
+        (OracleSource::PythLazer, OracleSource::PythLazer1M)
+        | (OracleSource::PythPull, OracleSource::Pyth1MPull) => (1_000_000, 1),
+        (OracleSource::PythLazer1M, OracleSource::PythLazer)
+        | (OracleSource::Pyth1MPull, OracleSource::PythPull) => (1, 1_000_000),
+        // 1K scaling relationships
+        (OracleSource::PythLazer, OracleSource::PythLazer1K)
+        | (OracleSource::PythPull, OracleSource::Pyth1KPull) => (1_000, 1),
+        (OracleSource::PythLazer1K, OracleSource::PythLazer)
+        | (OracleSource::Pyth1KPull, OracleSource::PythPull) => (1, 1_000),
+        _ => (1, 1),
     }
 }


### PR DESCRIPTION
## Fixes:
 liq price when spot oracle precision is different from perp market precision
ref: https://github.com/drift-labs/protocol-v2/blob/83321bd26e2577e440cba3c1c82a1f55e1407142/sdk/src/user.ts#L2393-L2401

## Changes:
made following functions public:
- `calculate_perp_free_collateral_delta`
- `calculate_spot_free_collateral_delta`