### PR TITLE
Fix bonk oracle precision with subscription

### DIFF
--- a/crates/src/blockhash_subscriber.rs
+++ b/crates/src/blockhash_subscriber.rs
@@ -169,7 +169,7 @@ mod tests {
 
         // after unsub, returns none
         blockhash_subscriber.unsubscribe();
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(Duration::from_secs(4)).await;
         assert!(blockhash_subscriber.get_latest_blockhash().is_none());
     }
 }

--- a/crates/src/lib.rs
+++ b/crates/src/lib.rs
@@ -696,6 +696,21 @@ impl DriftClient {
 
         Ok(())
     }
+
+    /// Return a reference to the internal spot market map
+    pub fn spot_market_map(&self) -> Arc<MapOf<u16, DataAndSlot<SpotMarket>>> {
+        self.backend.spot_market_map.map()
+    }
+
+    /// Return a reference to the internal perp market map
+    pub fn perp_market_map(&self) -> Arc<MapOf<u16, DataAndSlot<PerpMarket>>> {
+        self.backend.perp_market_map.map()
+    }
+
+    /// Return a reference to the internal oracle map
+    pub fn oracle_map(&self) -> Arc<MapOf<(Pubkey, u8), Oracle>> {
+        self.backend.oracle_map.map()
+    }
 }
 
 /// Provides the heavy-lifting and network facing features of the SDK

--- a/crates/src/marketmap.rs
+++ b/crates/src/marketmap.rs
@@ -25,6 +25,7 @@ use crate::{
     constants::{self, derive_perp_market_account, derive_spot_market_account, state_account},
     drift_idl::types::OracleSource,
     memcmp::get_market_filter,
+    types::MapOf,
     websocket_account_subscriber::WebsocketAccountSubscriber,
     DataAndSlot, MarketId, MarketType, PerpMarket, SdkResult, SpotMarket, UnsubHandle,
 };
@@ -95,6 +96,11 @@ where
             pubsub,
             commitment,
         }
+    }
+
+    /// Return a reference to the internal map data structure
+    pub fn map(&self) -> Arc<MapOf<u16, DataAndSlot<T>>> {
+        Arc::clone(&self.marketmap)
     }
 
     /// Subscribe to market account updates

--- a/crates/src/types.rs
+++ b/crates/src/types.rs
@@ -4,6 +4,7 @@ use std::{
     str::FromStr,
 };
 
+use dashmap::DashMap;
 pub use solana_rpc_client_api::config::RpcSendTransactionConfig;
 pub use solana_sdk::{
     commitment_config::CommitmentConfig, message::VersionedMessage,
@@ -31,6 +32,9 @@ use crate::{
     drift_idl::errors::ErrorCode,
     Wallet,
 };
+
+/// Map from K => V
+pub type MapOf<K, V> = DashMap<K, V, ahash::RandomState>;
 
 /// Handle for unsubscribing from network updates
 pub type UnsubHandle = oneshot::Sender<()>;


### PR DESCRIPTION
oraclemap is keyed by (pubkey, oracle source) to handle mixed precision between spot/perp markets (related https://github.com/drift-labs/protocol-v2/pull/1346)

- Add methods to exposed perp,sport, and oraclemaps on DriftClient