### PR TITLE
Jordy/initialize user ixs

### DIFF
--- a/crates/src/constants.rs
+++ b/crates/src/constants.rs
@@ -12,6 +12,10 @@ use crate::{
 pub const SYSVAR_INSTRUCTIONS_PUBKEY: Pubkey =
     solana_sdk::pubkey!("Sysvar1nstructions1111111111111111111111111");
 
+/// https://github.com/solana-foundation/solana-web3.js/blob/4e9988cfc561f3ed11f4c5016a29090a61d129a8/src/sysvar.ts#L19
+pub const SYSVAR_RENT_PUBKEY: Pubkey =
+    solana_sdk::pubkey!("SysvarRent111111111111111111111111111111111");
+
 /// Drift program address
 pub const PROGRAM_ID: Pubkey = solana_sdk::pubkey!("dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH");
 

--- a/crates/src/dlob/mod.rs
+++ b/crates/src/dlob/mod.rs
@@ -957,7 +957,7 @@ impl DLOB {
         let vamm_ask = perp_market
             .map(|m| m.calculate_ask_price())
             .unwrap_or_default();
-        log::debug!(target: "filler", "VAMM market={} bid={vamm_bid} ask={vamm_ask}", market_index);
+        log::trace!(target: "dlob", "VAMM market={} bid={vamm_bid} ask={vamm_ask}", market_index);
 
         let taker_asks = book.get_taker_asks(slot, oracle_price, perp_market);
         let taker_bids = book.get_taker_bids(slot, oracle_price, perp_market);
@@ -984,7 +984,8 @@ impl DLOB {
         let top_3_maker_bids: ArrayVec<Pubkey, 3> = taker_bids
             .iter()
             .by_ref()
-            .map(|o| self.metadata.get(&o.0).unwrap().user)
+            .take(3)
+            .filter_map(|o| self.metadata.get(&o.0).map(|m| m.user))
             .collect();
         // Check for crosses between auction bids and resting asks
         for (oid, price, size) in taker_bids {
@@ -1013,7 +1014,8 @@ impl DLOB {
         let top_3_maker_asks: ArrayVec<Pubkey, 3> = taker_asks
             .iter()
             .by_ref()
-            .map(|o| self.metadata.get(&o.0).unwrap().user)
+            .take(3)
+            .filter_map(|o| self.metadata.get(&o.0).map(|m| m.user))
             .collect();
         // Check for crosses between auction asks and resting bids
         for (oid, price, size) in taker_asks {

--- a/crates/src/lib.rs
+++ b/crates/src/lib.rs
@@ -2686,12 +2686,29 @@ impl<'a> TransactionBuilder<'a> {
     /// Initialize a new user account (subaccount) for the authority/wallet.
     ///
     /// Optionally set a custom name and referrer.
-    /// For sub_account_id=0, also initializes the user stats account.
+    /// For `sub_account_id = 0`, also initializes the user stats account.
     ///
     /// # Parameters
     /// - `sub_account_id`: The subaccount index to initialize (0 for main account).
     /// - `name`: Optional custom name for the account. If `None`, a default name is used.
-    /// - `referrer`: Optional referrer pubkey to for the account.
+    /// - `referrer`: Optional referrer pubkey for the account.
+    ///
+    /// # Example
+    /// ```
+    /// use drift_rs::{TransactionBuilder, Wallet};
+    /// use solana_sdk::pubkey::Pubkey;
+    ///
+    /// let wallet = Wallet::new_random();
+    /// let program_data = /* obtain ProgramData */;
+    /// let sub_account_id = 0;
+    /// let mut builder = TransactionBuilder::new(&program_data, wallet.default_sub_account(), /* user data */, false);
+    ///
+    /// // Initialize the user account and the swift account, then deposit 100_000 USDC (spot market 0)
+    /// builder = builder
+    ///     .initialize_user_account(sub_account_id, None, None)
+    ///     .initialize_swift_account()
+    ///     .deposit(100_000, 0, None);
+    /// ```
     pub fn initialize_user_account(
         mut self,
         sub_account_id: u16,

--- a/crates/src/lib.rs
+++ b/crates/src/lib.rs
@@ -8,7 +8,6 @@ use std::{
 };
 
 use anchor_lang::{AccountDeserialize, Discriminator, InstructionData};
-use arrayvec::ArrayString;
 use bytemuck::Pod;
 use constants::{
     high_leverage_mode_account, ASSOCIATED_TOKEN_PROGRAM_ID, PROGRAM_ID, SYSTEM_PROGRAM_ID,
@@ -1143,7 +1142,7 @@ impl DriftClientBackend {
                 },
             )
             .await
-            .map_err(SdkError::Grpc)?;
+            .map_err(|err| SdkError::Grpc(Box::new(err)))?;
 
         // oracle pubkeys are subscribed individually
         // due to ownership differences
@@ -1167,7 +1166,7 @@ impl DriftClientBackend {
                 },
             )
             .await
-            .map_err(SdkError::Grpc)?;
+            .map_err(|err| SdkError::Grpc(Box::new(err)))?;
 
         let mut unsub = self.grpc_unsub.write().unwrap();
         let _ = unsub.insert((grpc_unsub, oracles_grpc_unsub));
@@ -1348,7 +1347,7 @@ impl DriftClientBackend {
                 .rpc_client
                 .get_latest_blockhash()
                 .await
-                .map_err(SdkError::Rpc),
+                .map_err(|err| SdkError::Rpc(Box::new(err))),
         }
     }
 

--- a/crates/src/oraclemap.rs
+++ b/crates/src/oraclemap.rs
@@ -1,9 +1,6 @@
-use std::{
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-    u64,
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
 };
 
 use ahash::HashSet;

--- a/crates/src/swift_order_subscriber.rs
+++ b/crates/src/swift_order_subscriber.rs
@@ -522,7 +522,7 @@ mod tests {
             .unwrap();
         // signature, pubkey, len(u16)
         let payload = hex::decode(&ix.signed_msg_order_params_message_bytes[98..]).unwrap();
-        dbg!(payload[..8] == *SWIFT_MSG_PREFIX);
+        dbg!(payload[..8] == SWIFT_MSG_PREFIX);
 
         let res: SignedOrder = AnchorDeserialize::deserialize(&mut &payload[8..]).unwrap();
         dbg!(res);

--- a/crates/src/types.rs
+++ b/crates/src/types.rs
@@ -581,6 +581,13 @@ impl ReferrerInfo {
     }
 }
 
+impl Order {
+    pub const ORACLE_TRIGGER_MARKET_FLAG: u8 = 0b0000_0010;
+    pub fn is_oracle_trigger_market(&self) -> bool {
+        self.bit_flags & Self::ORACLE_TRIGGER_MARKET_FLAG != 0
+    }
+}
+
 impl OrderParams {
     pub const IMMEDIATE_OR_CANCEL_FLAG: u8 = 0b0000_0001;
     pub const HIGH_LEVERAGE_MODE_FLAG: u8 = 0b0000_0010;


### PR DESCRIPTION
## Adds
- PerpMarket: add VAMM price calculation methods (`calculate_bid_price`, `calculate_ask_price`)
- DLOB: add trigger order support
- TransactionBuilder: Add ixs for `initialize_user_account` and `initialize_signed_msg_acount` 
- FFI: `calculate_auction_params_for_trigger_order` simulate trigger order auction price

## Changes
- SdkEror: `Box`d the larger variant types
- TransactionBuilder: deposit/withdraw don't require the user's ATA parameter anymore, it will be derived automatically