### PR TITLE
fix: dlob stabilize internal order id

### DIFF
--- a/crates/src/dlob/mod.rs
+++ b/crates/src/dlob/mod.rs
@@ -635,7 +635,12 @@ impl DLOB {
     }
 
     fn update_order(&self, user: &Pubkey, slot: u64, new_order: Order, old_order: Order) {
-        let order_id = order_hash(user, new_order.order_id, new_order.market_index);
+        let order_id = order_hash(
+            user,
+            new_order.order_id,
+            new_order.market_index,
+            new_order.posted_slot_tail,
+        );
         log::trace!(target: TARGET, "update order: {order_id},{},{:?} @ {slot}", old_order.order_id, new_order.order_type);
 
         // Record update event
@@ -760,7 +765,12 @@ impl DLOB {
     }
 
     fn remove_order(&self, user: &Pubkey, slot: u64, order: Order) {
-        let order_id = order_hash(user, order.order_id, order.market_index);
+        let order_id = order_hash(
+            user,
+            order.order_id,
+            order.market_index,
+            order.posted_slot_tail,
+        );
 
         // Record remove event
         self.record_order_event(
@@ -831,7 +841,12 @@ impl DLOB {
     }
 
     fn insert_order(&self, user: &Pubkey, slot: u64, order: Order) {
-        let order_id = order_hash(user, order.order_id, order.market_index);
+        let order_id = order_hash(
+            user,
+            order.order_id,
+            order.market_index,
+            order.posted_slot_tail,
+        );
         log::trace!(target: TARGET, "insert order: {order_id} @ {slot}");
 
         if order.base_asset_amount <= order.base_asset_amount_filled {

--- a/crates/src/dlob/tests.rs
+++ b/crates/src/dlob/tests.rs
@@ -1399,7 +1399,8 @@ fn dlob_metadata_consistency_after_auction_expiry_and_removal() {
     dlob.insert_order(&user, slot, order);
 
     // Verify initial state - order should be in market_orders with LimitAuction metadata
-    let order_id = crate::dlob::util::order_hash(&user, 1, order.market_index);
+    let order_id =
+        crate::dlob::util::order_hash(&user, 1, order.market_index, order.posted_slot_tail);
     {
         let metadata = dlob.metadata.get(&order_id).unwrap();
         assert_eq!(metadata.kind, OrderKind::LimitAuction);
@@ -1498,7 +1499,8 @@ fn dlob_metadata_consistency_limit_auction_expiry_and_removal() {
     dlob.insert_order(&user, slot, order);
 
     // Verify initial state - order should be in market_orders with LimitAuction metadata
-    let order_id = crate::dlob::util::order_hash(&user, 1, order.market_index);
+    let order_id =
+        crate::dlob::util::order_hash(&user, 1, order.market_index, order.posted_slot_tail);
     {
         let metadata = dlob.metadata.get(&order_id).unwrap();
         assert_eq!(metadata.kind, OrderKind::LimitAuction);
@@ -1590,7 +1592,8 @@ fn dlob_metadata_consistency_floating_limit_auction_expiry_and_removal() {
     dlob.insert_order(&user, slot, order);
 
     // Verify initial state - order should be in oracle_orders with FloatingLimitAuction metadata
-    let order_id = crate::dlob::util::order_hash(&user, 1, order.market_index);
+    let order_id =
+        crate::dlob::util::order_hash(&user, 1, order.market_index, order.posted_slot_tail);
     {
         let metadata = dlob.metadata.get(&order_id).unwrap();
         assert_eq!(metadata.kind, OrderKind::FloatingLimitAuction);
@@ -1682,7 +1685,8 @@ fn dlob_trigger_order_transition_remove() {
     dlob.insert_order(&user, slot, order);
 
     // Verify initial state - order should be in trigger_orders
-    let order_id = crate::dlob::util::order_hash(&user, 1, order.market_index);
+    let order_id =
+        crate::dlob::util::order_hash(&user, 1, order.market_index, order.posted_slot_tail);
     {
         let metadata = dlob.metadata.get(&order_id).unwrap();
         assert_eq!(metadata.kind, OrderKind::TriggerMarket);
@@ -1751,7 +1755,8 @@ fn dlob_trigger_order_transition_update() {
     dlob.insert_order(&user, slot, order);
 
     // Verify initial state - order should be in trigger_orders
-    let order_id = crate::dlob::util::order_hash(&user, 1, order.market_index);
+    let order_id =
+        crate::dlob::util::order_hash(&user, 1, order.market_index, order.posted_slot_tail);
     {
         let metadata = dlob.metadata.get(&order_id).unwrap();
         assert_eq!(metadata.kind, OrderKind::TriggerMarket);

--- a/crates/src/dlob/util.rs
+++ b/crates/src/dlob/util.rs
@@ -23,11 +23,12 @@ pub enum OrderDelta {
 }
 
 /// Helper function to generate unique order Id hash for internal DLOB use
-pub fn order_hash(user: &Pubkey, order_id: u32, market_index: u16) -> u64 {
+pub fn order_hash(user: &Pubkey, order_id: u32, market_index: u16, posted_slot_tail: u8) -> u64 {
     let mut hasher = AHasher::default();
     user.hash(&mut hasher);
-    market_index.hash(&mut hasher);
     order_id.hash(&mut hasher);
+    market_index.hash(&mut hasher);
+    posted_slot_tail.hash(&mut hasher);
     hasher.finish()
 }
 


### PR DESCRIPTION
## Fix
- dlob: fix `find_crossing_region` method occasionaly returning empty cross
- dlob: internal order id include the order's market_index and posted_slot_tail

Due to a combination of head-of-chain forkiness and accounts that update orders very frequently, it was possible for two closely timed orders from the same account to be observed with the same internal order_id.

For example, the DLOB might initially observe an orderA with order_id = 5, later in the finalized state orderA is assigned order_id = 6 and another orderB is assigned order_id = 5. 

Users consuming finalized or otherwise reliable slot streams would generally not have experienced the issue