### PR TITLE
ci: pin GitHub Actions to commit SHAs (FE-4376)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,12 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: true
       - name: Cache Rust toolchain
         id: cache-rust-target-restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.rustup
@@ -71,7 +71,7 @@ jobs:
           TEST_MAINNET_PRIVATE_KEY: ${{ secrets.TEST_MAINNET_PRIVATE_KEY }}
           TEST_GRPC_X_TOKEN: ${{ secrets.TEST_GRPC_X_TOKEN }}
       - name: Cache Rust toolchain (save)
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         if: success() || failure()
         with:
           path: |

--- a/.github/workflows/on-libdrift-update.yml
+++ b/.github/workflows/on-libdrift-update.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubicloud
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: true
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -52,7 +52,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/on-program-update.yml
+++ b/.github/workflows/on-program-update.yml
@@ -35,14 +35,14 @@ jobs:
       CARGO_DRIFT_FFI_PATH: /usr/lib
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Update IDL
         run: |
           curl -H 'Accept: application/vnd.github.v3.raw' 'https://api.github.com/repos/drift-labs/protocol-v2/contents/sdk/src/idl/drift.json?ref=tags/${{ needs.check-version.outputs.idl_version }}' > res/drift.json
 
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           profile: minimal
           toolchain: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubicloud
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           submodules: true
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: install 1.76.0 toolchain
         run: |
           rustup install 1.76.0-x86_64-unknown-linux-gnu
@@ -56,7 +56,7 @@ jobs:
         repo: ['gateway', 'swift']
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           submodules: true


### PR DESCRIPTION
## What

Pin all floating GitHub Actions refs in this repo to full commit SHAs (with `# version` comments), across workflow files and composite `action.yml` files. SHAs are the exact commits each tag/branch currently resolves to.

## Why

Part of the org-wide GitHub Actions hardening effort ([FE-4376](https://linear.app/driftprotocol/issue/FE-4376/improve-github-actions-security)). The `drift-labs` org now has `sha_pinning_required: true` and is moving off `Allow all actions` to a selected-actions allow-list. Floating refs (`@v1`, `@master`, …) must be pinned to full SHAs first so neither the pin-enforcement policy nor the allow-list flip breaks CI. Pinning to a SHA is the actual supply-chain defense (a mutable `@master`/tag can be moved by a compromised maintainer).

## Scope

Action ref pins only — no logic changes. Behavior preserved (e.g. `dtolnay/rust-toolchain@stable` pins to the stable-branch commit whose `action.yml` still defaults to the stable channel).