### PR TITLE
chore: rename drift-labs GitHub URLs to velocity-exchange

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           # NB: this will break historic CI jobs (if breaking program changes happen)
           # better to ensure latest version works
-          SO_URL=$(curl -s https://api.github.com/repos/drift-labs/drift-ffi-sys/releases/latest | jq -r '.assets[] | select(.name=="libdrift_ffi_sys.so") | .browser_download_url')
+          SO_URL=$(curl -s https://api.github.com/repos/velocity-exchange/drift-ffi-sys/releases/latest | jq -r '.assets[] | select(.name=="libdrift_ffi_sys.so") | .browser_download_url')
           echo "downloading libdrift: $SO_URL"
           curl -L -o libdrift_ffi_sys.so "$SO_URL"
           sudo cp libdrift_ffi_sys.so $CARGO_DRIFT_FFI_PATH

--- a/.github/workflows/manual-idl-update.yml
+++ b/.github/workflows/manual-idl-update.yml
@@ -18,5 +18,5 @@ jobs:
         -H "Accept: application/vnd.github+json" \
         -H "Authorization: token ${{ secrets.GH_PAT }}" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
-        https://api.github.com/repos/drift-labs/drift-rs/dispatches \
+        https://api.github.com/repos/velocity-exchange/drift-rs/dispatches \
         -d '{"event_type":"sdk-update","client_payload":{"version":"${{ github.event.inputs.version }}"}}'

--- a/.github/workflows/on-program-update.yml
+++ b/.github/workflows/on-program-update.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check update version
         id: version-check
         run: |
-          VERSION=$(curl -s "https://api.github.com/repos/drift-labs/protocol-v2/tags" | grep -m 1 "name" | cut -d '"' -f 4)
+          VERSION=$(curl -s "https://api.github.com/repos/velocity-exchange/protocol-v2/tags" | grep -m 1 "name" | cut -d '"' -f 4)
           echo "idl_version=$VERSION" >> $GITHUB_OUTPUT
 
           # Check if version contains beta, alpha, or rc tags
@@ -39,7 +39,7 @@ jobs:
 
       - name: Update IDL
         run: |
-          curl -H 'Accept: application/vnd.github.v3.raw' 'https://api.github.com/repos/drift-labs/protocol-v2/contents/sdk/src/idl/drift.json?ref=tags/${{ needs.check-version.outputs.idl_version }}' > res/drift.json
+          curl -H 'Accept: application/vnd.github.v3.raw' 'https://api.github.com/repos/velocity-exchange/protocol-v2/contents/sdk/src/idl/drift.json?ref=tags/${{ needs.check-version.outputs.idl_version }}' > res/drift.json
 
       - name: Setup Rust
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
@@ -50,7 +50,7 @@ jobs:
       - name: Generate Rust types
         run: |
           # libdrift install
-          SO_URL=$(curl -s https://api.github.com/repos/drift-labs/drift-ffi-sys/releases/latest | jq -r '.assets[] | select(.name=="libdrift_ffi_sys.so") | .browser_download_url')
+          SO_URL=$(curl -s https://api.github.com/repos/velocity-exchange/drift-ffi-sys/releases/latest | jq -r '.assets[] | select(.name=="libdrift_ffi_sys.so") | .browser_download_url')
           echo "downloading libdrift: $SO_URL"
           curl -L -o libdrift_ffi_sys.so "$SO_URL"
           sudo cp libdrift_ffi_sys.so $CARGO_DRIFT_FFI_PATH && rm libdrift_ffi_sys.so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           # add libdrift_ffi_sys
           FFI_VERSION=$(grep '^version = ' crates/drift-ffi-sys/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
-          curl -L https://github.com/drift-labs/drift-ffi-sys/releases/download/v$FFI_VERSION/libdrift_ffi_sys.so > libdrift_ffi_sys.so
+          curl -L https://github.com/velocity-exchange/drift-ffi-sys/releases/download/v$FFI_VERSION/libdrift_ffi_sys.so > libdrift_ffi_sys.so
           sudo mv libdrift_ffi_sys.so $CARGO_DRIFT_FFI_PATH
           # publish to crates.io
           cargo -V
@@ -72,5 +72,5 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.REPO_DISPATCH_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/drift-labs/${{ matrix.repo }}/dispatches \
+            https://api.github.com/repos/velocity-exchange/${{ matrix.repo }}/dispatches \
             -d "{\"event_type\":\"drift_rs_release\",\"client_payload\":{\"tag\":\"$TAG\",\"ffi_version\":\"$FFI_VERSION\"}}"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "crates/drift-ffi-sys"]
 	path = crates/drift-ffi-sys
-	url = https://github.com/drift-labs/drift-ffi-sys
+	url = https://github.com/velocity-exchange/drift-ffi-sys

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,7 +1987,7 @@ dependencies = [
 [[package]]
 name = "jupiter-swap-api-client"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/jupiter-swap-api-client?rev=424ad8#424ad83959e306e3a3aff73c0a1ab1a2b4aa9509"
+source = "git+https://github.com/velocity-exchange/jupiter-swap-api-client?rev=424ad8#424ad83959e306e3a3aff73c0a1ab1a2b4aa9509"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4781,7 +4781,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "titan-swap-api-client"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/titan-swap-api-client.git#9ef7df6753c6378d5ed0f2cfdeb44b66d2669632"
+source = "git+https://github.com/velocity-exchange/titan-swap-api-client.git#9ef7df6753c6378d5ed0f2cfdeb44b66d2669632"
 dependencies = [
  "anyhow",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 build = "build.rs"
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/drift-labs/drift-rs"
+repository = "https://github.com/velocity-exchange/drift-rs"
 homepage = "https://drift.trade"
 description = """
 Rust SDK for Drift V2 Protocol on the Solana blockchain.
@@ -38,7 +38,7 @@ env_logger = "0.11"
 futures-util = "0.3"
 fxhash = "0.2.1"
 hex = "0.4"
-jupiter-swap-api-client = { git = "https://github.com/drift-labs/jupiter-swap-api-client", rev = "424ad8", package = "jupiter-swap-api-client" }
+jupiter-swap-api-client = { git = "https://github.com/velocity-exchange/jupiter-swap-api-client", rev = "424ad8", package = "jupiter-swap-api-client" }
 log = "0.4"
 regex = "1.10"
 serde = { version = "1", features = ["derive"] }
@@ -60,7 +60,7 @@ solana-transaction = "3"
 solana-transaction-status = "3"
 spl-associated-token-account = "8.0"
 thiserror = "1"
-titan-swap-api-client = { git = "https://github.com/drift-labs/titan-swap-api-client.git", optional = true }
+titan-swap-api-client = { git = "https://github.com/velocity-exchange/titan-swap-api-client.git", optional = true }
 tokio = { version = "1.48", features = ["full"] }
 tokio-stream = "0.1.17"
 tokio-tungstenite = { version = "0.28", features = ["native-tls"] }

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ See the official [docs](https://docs.rs/drift-rs/latest/drift_rs/)
 
 ## Install
 ```toml
-drift-rs = { git = "https://github.com/drift-labs/drift-rs", tag = "v1.0.0" }
+drift-rs = { git = "https://github.com/velocity-exchange/drift-rs", tag = "v1.0.0" }
 ```
-_*_ crates.io requires [libdrift](https://github.com/drift-labs/drift-ffi-sys/?tab=readme-ov-file#from-source) is installed and linked locally
+_*_ crates.io requires [libdrift](https://github.com/velocity-exchange/drift-ffi-sys/?tab=readme-ov-file#from-source) is installed and linked locally
 
 
 ## Use
@@ -100,11 +100,11 @@ rustup override set 1.85.0-x86_64-unknown-linux-gnu
 ⚠️ the non-x86_64 toolchains are incompatible due to memory layout differences between solana program (BPF) and aarch64 and will fail at runtime with deserialization errors like: `InvalidSize`.
 
 ## Local Development
-drift-rs links to the drift program crate via FFI, build from source (default) by cloning git submodule or dynamically link with a version from [drift-ffi-sys](https://github.com/drift-labs/drift-ffi-sys/releases)
+drift-rs links to the drift program crate via FFI, build from source (default) by cloning git submodule or dynamically link with a version from [drift-ffi-sys](https://github.com/velocity-exchange/drift-ffi-sys/releases)
 
 **clone repo and submodules**
 ```bash
-git clone https://github.com/drift-labs/drift-rs &&\
+git clone https://github.com/velocity-exchange/drift-rs &&\
 cd drift-rs &&\
 git submodule update --init --recursive
 ```

--- a/crates/drift-idl-gen/Cargo.toml
+++ b/crates/drift-idl-gen/Cargo.toml
@@ -3,7 +3,7 @@ name = "drift-idl-gen"
 version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/drift-labs/drift-rs"
+repository = "https://github.com/velocity-exchange/drift-rs"
 description = "Generates Drift v2 structs/types from anchor IDL"
 
 [lib]

--- a/crates/pubsub-client/Cargo.toml
+++ b/crates/pubsub-client/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/drift-labs/drift-rs"
+repository = "https://github.com/velocity-exchange/drift-rs"
 description = "Solana Pubsub Client patched with proper connection handling"
 
 [dependencies]

--- a/examples/dlob-builder/Cargo.lock
+++ b/examples/dlob-builder/Cargo.lock
@@ -2358,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "jupiter-swap-api-client"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/jupiter-swap-api-client?branch=patch%2F2025-12-28#6b07ee58ff4c3c5e4f0b9b35d13d9d37e4069202"
+source = "git+https://github.com/velocity-exchange/jupiter-swap-api-client?branch=patch%2F2025-12-28#6b07ee58ff4c3c5e4f0b9b35d13d9d37e4069202"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/examples/drift-client-callbacks/Cargo.lock
+++ b/examples/drift-client-callbacks/Cargo.lock
@@ -2557,7 +2557,7 @@ dependencies = [
 [[package]]
 name = "jupiter-swap-api-client"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/jupiter-swap-api-client#b699edf30ff1f561460579ee2504622e28f9a797"
+source = "git+https://github.com/velocity-exchange/jupiter-swap-api-client#b699edf30ff1f561460579ee2504622e28f9a797"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/examples/event-subscriber/Cargo.lock
+++ b/examples/event-subscriber/Cargo.lock
@@ -2489,7 +2489,7 @@ dependencies = [
 [[package]]
 name = "jupiter-swap-api-client"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/jupiter-swap-api-client#b699edf30ff1f561460579ee2504622e28f9a797"
+source = "git+https://github.com/velocity-exchange/jupiter-swap-api-client#b699edf30ff1f561460579ee2504622e28f9a797"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/examples/swift-maker/Cargo.lock
+++ b/examples/swift-maker/Cargo.lock
@@ -2296,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "jupiter-swap-api-client"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/jupiter-swap-api-client?branch=patch%2F2025-12-28#8a03d2a8e1017de9c54ee2c12532083812c13cf2"
+source = "git+https://github.com/velocity-exchange/jupiter-swap-api-client?branch=patch%2F2025-12-28#8a03d2a8e1017de9c54ee2c12532083812c13cf2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/examples/swift-taker/Cargo.lock
+++ b/examples/swift-taker/Cargo.lock
@@ -2350,7 +2350,7 @@ dependencies = [
 [[package]]
 name = "jupiter-swap-api-client"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/jupiter-swap-api-client?branch=patch%2F2025-12-28#8a03d2a8e1017de9c54ee2c12532083812c13cf2"
+source = "git+https://github.com/velocity-exchange/jupiter-swap-api-client?branch=patch%2F2025-12-28#8a03d2a8e1017de9c54ee2c12532083812c13cf2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/scripts/idl-update.sh
+++ b/scripts/idl-update.sh
@@ -1,1 +1,1 @@
- curl -H 'Accept: application/vnd.github.v3.raw' 'https://api.github.com/repos/drift-labs/protocol-v2/contents/sdk/src/idl/drift.json' > res/drift.json
+ curl -H 'Accept: application/vnd.github.v3.raw' 'https://api.github.com/repos/velocity-exchange/protocol-v2/contents/sdk/src/idl/drift.json' > res/drift.json


### PR DESCRIPTION
Part of renaming the GitHub org drift-labs -> velocity-exchange.

DRAFT — do not merge until the velocity-exchange org (and, where applicable, the @velocity-exchange npm scope) exists; old URLs currently redirect.

## URL forms changed

- github.com/drift-labs/<repo> -> github.com/velocity-exchange/<repo> (Cargo.toml, Cargo.lock, README.md, build.rs, CHANGELOG.md, .gitmodules, crates Cargo.toml files, example Cargo.lock files)
- api.github.com/repos/drift-labs/<repo> -> api.github.com/repos/velocity-exchange/<repo> (GitHub Actions workflows, scripts/idl-update.sh)

Total: 33 substitutions across 18 files.

## Skipped (upstream-Drift historical refs)

- README.md:16 — building offchain clients for [Drift V2](https://github.com/drift-labs/protocol-v2) protocol — kept as historical/upstream description
- crates/src/lib.rs:4156 — code comment referencing drift-labs/protocol-v2 optional_accounts.rs — kept as external upstream reference
- examples/market-maker/README.md:25 — link to drift-labs/jit-proxy — kept as reference to an external third-party project

## Note on Cargo git dependencies

jupiter-swap-api-client and titan-swap-api-client Cargo dependencies are now pointed at velocity-exchange/ org. Builds will break until those repos are forked/mirrored under the velocity-exchange org at the same commit SHAs. Similarly, on-program-update.yml now fetches the IDL from velocity-exchange/protocol-v2 — ensure that repo exists and has the expected tag/IDL structure before this workflow runs.